### PR TITLE
Add markdowns on building kernel on FC37

### DIFF
--- a/debug/README
+++ b/debug/README
@@ -1,0 +1,16 @@
+This files should not be treated as scripts, but rather as notes on
+how to do that on Fedora 37. The sources were downloaded from
+https://www.kernel.org/ as a tarball and untarred with simple "tar -x"
+
+debug/VirtualBoxSetup.md        -how to setup VBox environment
+debug/build_kernel.md           -how to build kernel with right config
+debug/hostSetup.md              -setup host and run gdb (kgdboc)
+debug/mod_kernel_boot_param.md  -what kernel boot parameters to set
+debug/gdbline                   -create line to provide to gdb on host
+
+can echo on taget and cat on host to check correctness of connection
+target: `printf "foo\r" > /dev/ttyS0`
+hots:   `cat /dev/ttyS0` should print the "foo"
+
+kgdbwait (boot param) can be ommited if no waiting for gdb on boot
+process is required.

--- a/debug/VirtualBoxSetup.md
+++ b/debug/VirtualBoxSetup.md
@@ -1,0 +1,14 @@
+Virtualbox needs adjustments
+
+Serial port forwarding need to be enabled:
+	regarding guest:
+			seettings -> Serial Ports -> Port 1 -> Enable Serial Port, COM1, IRQ 4, I/O Port: 0x3f8, Port MOde: Host Pipe, Path/Address: \\.\pipe\mtlepipe
+	regarding host:
+			seettings -> Serial Ports -> Port 1 -> Enable Serial Port, COM1, IRQ 4, I/O Port: 0x3f8, Port MOde: Host Pipe, Connetct to existing pipe/socket, Path/Address: \\.\pipe\mtlepipe
+
+	Test above settings:
+    	in host:
+    		cat /dev/ttyS0
+    	in guest:
+    		printf "test string\r" >> /dev/ttyS0
+            # this should print "test string" in the host

--- a/debug/build_kernel.md
+++ b/debug/build_kernel.md
@@ -1,0 +1,57 @@
+#!/bin/bash
+#
+# BASED on 
+# https://wiki.linuxquestions.org/wiki/How_to_build_and_install_your_own_Linux_kernel
+printf "Most of this SHOULD be run as a non-root user!\n\
+        This are just notes!\n\
+        This code was never tested.\n\
+        However, the commands here were executed in the same order\n
+        These might work on Fedora 37\n\n"
+
+COPIED_LINUX_VERSION="linux-6.1.12"
+MTLE_APPENDIX=".MTLE" # to distinguish our files
+
+HOME="home/ml/"
+ROOT=${HOME}/${COPIED_LINUX_VERSION}
+
+cd ${HOME}
+wget https://cdn.kernel.org/pub/linux/kernel/v6.x/${COPIED_LINUX_VERSION}.tar.xz
+tar -x ${COPIED_LINUX_VERSION}
+cd ${ROOT}
+
+#git clone git://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
+
+sudo yum groupinstall "Development Tools"
+sudo yum install ncurses-devel bison flex elfutils-libelf-devel openssl-devel openssl.x86_64
+
+make menuconfig
+# CONFIG_GDB_SCRIPTS=y
+# CONFIG_KGDB=y
+# CONFIG_KGDB_SERIAL_CONSOLE=y
+# CONFIG_KGDB_KDB=y
+# CONFIG_KDB_DEFAULT_ENABLE=0x1 to allow most KGDB functions
+
+
+#THIS NEEDS TO BE RUN AS A NORMAL USER!!!
+# if returns 137 error (out of mem) on VM, just increase RAM
+make -j
+
+#THIS NEEDS TO BE RUN AS A SUPER USER!!!
+sudo make -j modules_install
+
+# need to make this kernel bootable now
+# this may overwrite your previous settings
+sudo make install
+# 2nd method is to install new(ly compiled) kernel, copy the bzImage file and the system map file by hand to the /boot directory of your system, using:
+#sudo cp arch/x86/boot/bzImage  /boot/bzImage-${COPIED_LINUX_VERSION}${MTLE_APENDIX} #(replace x86 if necessary by your actual CPU architecture)
+#sudo cp System.map /boot/System.map-${COPIED_LINUX_VERSION}${MTLE_APENDIX}
+# copy the final .config file to /boot (for storage and future reference) :
+#sudo cp .config /boot/config-${COPIED_LINUX_VERSION}${MTLE_APENDIX}
+
+
+
+# vmlinux can be built by:
+#make -j vmlinux
+
+
+

--- a/debug/gdbline
+++ b/debug/gdbline
@@ -1,0 +1,18 @@
+#!/bin/bash
+#
+# $Id: gdbline,v 1.1 2004/08/02 16:27:55 corbet Exp $
+#
+# gdbline module image
+#
+# Outputs an add-symbol-file line suitable for pasting into gdb to examine
+# a loaded module.
+#
+cd /sys/module/$1/sections
+echo -n add-symbol-file $2 `/bin/cat .text`
+
+for section in .[a-z]* *; do
+    if [ $section != ".text" ]; then
+	    echo -n "       -s" $section `/bin/cat $section`
+    fi
+done
+echo

--- a/debug/hostSetup.md
+++ b/debug/hostSetup.md
@@ -1,0 +1,6 @@
+Need to copy compiled vmlinux from target to the host, say to the /boot/kgdb-image/ (this is the convention)
+
+in directory, where vmlinux is, run "gdb ./vmlinux"
+
+if you're set up with ttyS0, then in gdb run: 
+    target remote /dev/ttyS0

--- a/debug/mod_kernel_boot_param.md
+++ b/debug/mod_kernel_boot_param.md
@@ -1,0 +1,12 @@
+
+ON TARGET:
+
+vim /etc/default/grub
+    GRUB_CMDLINE_LINUX="nomodeset rhgb debug nokaslr kgdboc=/dev/ttyS0,115200 kgdbwait"
+    instead of
+    GRUB_CMDLINE_LINUX="nomodeset rhgb quiet"
+    # the 'debug' option makes it easier to debug system booting (prints extended info to tty and syslog)
+
+
+grub2-mkconfig -o /etc/grub2.cfg
+

--- a/debug/real_world_example.md
+++ b/debug/real_world_example.md
@@ -1,0 +1,26 @@
+copied from target to the host:
+	vmlinux	        		        (~/Downloads/)
+	cmopiled linux sources      	(/src/usr/kernels/linux-6.1.12/)
+	sources of and module itself    (~/Downloads/driver/)
+		sudo ln -s /home/mtle/Downloads/driver/ /home/ml/Desktop/learning/linux_drivers_upskilling/04_char_dev_proc_test_breakpoints # gdb needs sources
+target:
+	sh /home/ml/Desktop/learning/linux_drivers_upskilling/gdbline hello /home/mtle/Downloads/driver/hello.ko
+	# output will be copied to gdb on host (path of hello.ko need to be compiliant with the one on the host)
+	echo g > /proc/sysrq-trigger	# debug mode
+host:
+	cd /home/mtle/Downloads/linux-6.1.12
+	gdb ../vmlinux 
+	(gdb) add-symbol-file /home/mtle/Downloads/driver/hello.ko 0xffffffffc0642000       -s .bss 0xffffffffc0644680       -s .data 0xffffffffc0644020       -s .exit.data 0xffffffffc06441d0       -s .exit.text 0xffffffffc0642573       -s .gnu.linkonce.this_module 0xffffffffc0644280       -s .init.data 0xffffffffc024b000       -s .note.gnu.build-id 0xffffffffc0643ba0       -s .note.gnu.property 0xffffffffc0643b70       -s .note.Linux 0xffffffffc0643bc4       -s .orc_unwind 0xffffffffc0643940       -s .orc_unwind_ip 0xffffffffc0643a90       -s .printk_index 0xffffffffc06441d8       -s .return_sites 0xffffffffc0643910       -s .rodata 0xffffffffc0643060       -s .strtab 0xffffffffc024ce70       -s .symtab 0xffffffffc024c000       -s __bug_table 0xffffffffc0644000       -s __mcount_loc 0xffffffffc0643000       -s __param 0xffffffffc0643898	# this is an output from gdbline command ran on the target
+	(gdb) b ct_seq_next # set breakpoint on function within debugged module
+		Breakpoint 1 at 0xffffffffc0642000: file /home/ml/Desktop/learning/linux_drivers_upskilling/04_char_dev_proc_test_breakpoints/hello.c, line 152.
+	(gdb) b hello_init
+	
+	(gdb) target remote /dev/ttyS0
+		# should return similar lines to:
+			Remote debugging using /dev/ttyS0
+			kgdb_breakpoint () at kernel/debug/debug_core.c:1219
+				1219		wmb(); /* Sync point after breakpoint */
+	(gdb) c
+target:
+	insmod hello.ko
+	cat /dev/mtle_sequence


### PR DESCRIPTION
This files should not be treated as scripts, but rather as notes on how to do that on Fedora 37. The sources were downloaded from https://www.kernel.org/ as a tarball and untarred with simple "tar -x"

debug/VirtualBoxSetup.md        -how to setup VBox environment
debug/build_kernel.md           -how to build kernel with right config
debug/hostSetup.md              -setup host and run gdb (kgdboc)
debug/mod_kernel_boot_param.md  -what kernel boot parameters to set
debug/gdbline                   -create line to provide to gdb on host

can echo on taget and cat on host to check correctness of connection target: `printf "foo\r" > /dev/ttyS0`
hots:   `cat /dev/ttyS0` should print the "foo"

kgdbwait (boot param) can be ommited if no waiting for gdb on boot process is required.